### PR TITLE
Make flashcards window resizable

### DIFF
--- a/flashcards.py
+++ b/flashcards.py
@@ -9,7 +9,7 @@ class FlashcardApp:
         master.title("Flashcards de Japonés")
         master.geometry("600x500")
         # Evita que el tamaño de la ventana cambie y los botones se oculten
-        master.resizable(False, False)
+        master.resizable(True, True)
         
         # Variables generales
         self.all_cards = []


### PR DESCRIPTION
## Summary
- enable window resizing in the flashcards application

## Testing
- `python3 -m py_compile flashcards.py`

------
https://chatgpt.com/codex/tasks/task_e_68883a33e33c83298fe3474a2ea6599f