### PR TITLE
Improve smart study mode

### DIFF
--- a/flashcards.py
+++ b/flashcards.py
@@ -230,7 +230,10 @@ class FlashcardApp:
             stat = self.stats.get(card.get("id"), {"shown": 0, "correct": 0})
             shown = stat["shown"]
             acc = stat["correct"] / shown if shown > 0 else 0
-            return (acc, shown)
+            # Unseen cards have shown == 0. Using -shown ensures previously
+            # reviewed cards with the same accuracy are prioritized over unseen
+            # ones when sorting.
+            return (acc, -shown)
 
         ordered = sorted(self.all_cards, key=metric)
         self.session_cards = ordered[:num]


### PR DESCRIPTION
## Summary
- adjust the smart mode metric so cards previously shown get priority over unseen cards

## Testing
- `python3 -m py_compile flashcards.py`


------
https://chatgpt.com/codex/tasks/task_e_68884d9c32408329b38fee5c5aeea0dc